### PR TITLE
Fixed number of random reads by bcrypt cost 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Using these parameters...
 
 #### bcrypt
 * Uses 4 KiB of memory (resident in L1 cache)
-* Performs 6,538,944 random 32-bit reads
+* Performs 2,185,278,016 random 32-bit reads
 * ... and that's it. That's all it's got.
 
-In other words, in nearly the same duration of time, Pufferfish2 performs 82.5x more random reads than bcrypt (64-bit vs 32-bit as well), plus performs pre-hashing and sequential read-hash-write operations on 128.75 MiB of data. 
+In other words, in nearly the same duration of time, Pufferfish2 performs 1/4.1x the random reads as bcrypt (64-bit vs 32-bit as well), plus performs pre-hashing and sequential read-hash-write operations on 128.75 MiB of data.
 
 From this example, it is overwhelmingly obvious to see that Pufferfish2 is much stronger than bcrypt, while providing much better GPU resistance than bcrypt.
 


### PR DESCRIPTION
TL;DR
`randomReads = ((numberOfPboxInts * sizeOfInt + numberOfSboxInts * sizeOfInt) * (1 + 2 * 2 ** cost) + finishTimesEncrypted * finishMessageSize) / bytesPerBlockEncrypt * 4 * numberOfRounds`
`2,185,278,016 = ((18 * 4 + 256*4 * 4) * (1 + 2 * 2 ** 15) + 64 * 24) / 8 * 4 * 16`

Expand key calls encrypt `(numberOfPboxInts * sizeOfInt + numberOfSboxInts * sizeOfInt) / bytesPerBlockEncrypt` times. `521 = (18 * 4 + 256 * 4 * 4) / 8`
Encrypt does `4 * numberOfRounds` random reads. `64 = 4 * 16`
Expand key does `521 * 64` random reads. `33,344 = 521 * 64`
Expand key is called `1 + 2 * 2 ** cost` times. Cost=15: `65,537 = 1 + 2 * 2 ** 15`
Finishing calls encrypt `finishTimesEncrypted * finishMessageSize / bytesPerBlockEncrypt` times. `192 = 64 * 24 / 8`
All together that's `2,185,278,016 = 65,537 * 33,344 + 192 * 64` random reads.

I also modified an implementation of bcrypt to output the number of random reads and got the same answer. Also 1/4 is what I was expecting for Pufferfish when you count the random look ups to L2 cache (takes 2x as L1 cache) and count SHA512 operations.