### PR TITLE
Update pufferfish.c to use ENOATTR when ENODATA is not defined (on BSD systems)

### DIFF
--- a/pufferfish.c
+++ b/pufferfish.c
@@ -201,7 +201,11 @@ int pf_mksalt(const void *salt_r, const size_t salt_sz, const uint8_t cost_t, co
         fclose(fp);
 
         if (bytes != PF_SALT_SZ)
-            return ENODATA;
+            #ifdef ENODATA
+                return ENODATA;
+            #else
+                return ENOATTR;
+            #endif
     }
     else
     {


### PR DESCRIPTION
BSD systems have ENODATA undefined.
This make the code compiles on both Linux and BSD.